### PR TITLE
Supporting Jekyll 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ in [jekyll][].
 Warnings for Existing Users
 ---------------------------
 
-Thanks to @ivotron, the plugin has been rewritten to work with Jekyll 1.0.0. For older versions of Jekyll, you may wish to use the older version, which has the `old-version` tag.
+### Jekyll < 1.0.0
+
+Thanks to @ivotron, the plugin has been rewritten to work with Jekyll 1.0.0. The old version, which works with Jekyll < 1.0.0, can be found on the for-use-with-jekyll-pre-1.0.0 branch. 
+
+### HTML5
 
 After this [recent commit](https://github.com/dsanson/jekyll-pandoc-plugin/commit/8dd292f483cb81e008d769b4588f4cfb118b1d11), the plugin uses pandoc's `html5` output instead of `html`. This may break your existing CSS styling. See [Issue 3](https://github.com/dsanson/jekyll-pandoc-plugin/issues/3) for discussion.
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,15 @@ can add something like
     pandoc:
        extensions: [smart, mathjax]
 
-to your `_config.yml` file. (For how to deal with complex options, take
-a look at the [pandoc-ruby][] documentation.)
+to your `_config.yml` file. For more complex options that involve arguments, you will want something like
+
+    pandoc:
+        extensions:
+            - smart
+            - csl: 'apa.csl'
+            - bibliography: 'references.bib'
+
+
 
 Github Pages
 ------------

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ Jekyll Plugin for Using Pandoc-Ruby
 This is a plugin for using [pandoc][] as your markdown converter
 in [jekyll][].
 
+I am No Longer Maintaining This
+-------------------------------
+
+**I switched to using [Hakyll](http://jaspervdj.be/hakyll/) a year or two ago,
+and stopped using this plugin. In the meantime, Jekyll has gone through
+some major updates. There are two reasonable sounding pull requests, aimed
+at making the plugin work with recent updates. I am
+not going to pull them, because I cannot test them, and I don't want to 
+pretend to maintain something that I am not really maintaining.**
+
+You should probably use one of the more up-to-date forks instead of this repo.
+
 Warnings for Existing Users
 ---------------------------
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Jekyll Plugin for Using Pandoc-Ruby
 ===================================
 
 This is a plugin for using [pandoc][] as your markdown converter
-[jekyll][].
+in [jekyll][].
 
 Installation
 ------------
@@ -12,7 +12,7 @@ pandoc. You can install pandoc-ruby with:
 
     gem install pandoc-ruby
 
-To install the plugin, copy `pandoc_markdown.rb` into the `_plugins`
+To install this plugin, copy `pandoc_markdown.rb` into the `_plugins`
 directory in your site source root (if no `_plugins` directory exists,
 create it.)
 
@@ -35,22 +35,23 @@ a look at the [pandoc-ruby][] documentation.)
 Github Pages
 ------------
 
-The plugin will not work with github pages. If you set
-`markdown: pandoc` in your `_config.yml`, then, on github pages, that
-will be ignored, and your pages will be converted with the default
-markdown converter.
+The plugin will not work with [github pages][]. If you set
+`markdown: pandoc` in your `_config.yml`, github pages will ignore this
+setting, and the default markdown converter will be used.
 
-As a partial work around, if you set your preferred github-approved
-markdown converter in `_config.yml` and *also* set the `pandoc`
-variable, then the plugin will locally use pandoc to convert markdown.
-So, for example, a `_config.yml` containing both
+I use github pages to mirror my official site. My official site is built
+by jekyll using pandoc. I want my github mirror to be built using
+rdiscount, and I don't want to maintain two separate `_config.yml`
+files. My `_config.yml` file contains lines that look like this:
 
     markdown:  rdiscount
     pandoc:
        extensions: [smart, mathjax]
 
-will be converted using rdiscount on github pages, and pandoc locally.
-To get the same effect, but without passing any options to pandoc, try
+The plugin sees that the `pandoc` option has been set, and so uses
+pandoc. Github pages ignores the `pandoc` option, and sees that
+`markdown` has been set to rdiscount. To get the same effect, but
+without passing any options to pandoc, try
 
     markdown:  rdiscount
     pandoc:  true
@@ -58,3 +59,4 @@ To get the same effect, but without passing any options to pandoc, try
   [pandoc]: (http://johnmacfarlane.net/pandoc/
   [jekyll]: https://github.com/mojombo/jekyll
   [pandoc-ruby]: https://github.com/alphabetum/pandoc-ruby
+  [github pages]: http://pages.github.com/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Jekyll Plugin for Using Pandoc-Ruby
 This is a plugin for using [pandoc][] as your markdown converter
 in [jekyll][].
 
+Warning for Existing Users
+--------------------------
+
+After this [recent commit](https://github.com/dsanson/jekyll-pandoc-plugin/commit/8dd292f483cb81e008d769b4588f4cfb118b1d11), the plugin uses pandoc's `html5` output instead of `html`. This may break your existing CSS styling. See [Issue 3](https://github.com/dsanson/jekyll-pandoc-plugin/issues/3) for discussion.
+
 Installation
 ------------
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Jekyll Plugin for Using Pandoc-Ruby
 This is a plugin for using [pandoc][] as your markdown converter
 in [jekyll][].
 
-Warning for Existing Users
---------------------------
+Warnings for Existing Users
+---------------------------
+
+Thanks to @ivotron, the plugin has been rewritten to work with Jekyll 1.0.0. For older versions of Jekyll, you may wish to use the older version, which has the `old-version` tag.
 
 After this [recent commit](https://github.com/dsanson/jekyll-pandoc-plugin/commit/8dd292f483cb81e008d769b4588f4cfb118b1d11), the plugin uses pandoc's `html5` output instead of `html`. This may break your existing CSS styling. See [Issue 3](https://github.com/dsanson/jekyll-pandoc-plugin/issues/3) for discussion.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ Thanks to @ivotron, the plugin has been rewritten to work with Jekyll 1.0.0. The
 
 ### HTML5
 
-After this [recent commit](https://github.com/dsanson/jekyll-pandoc-plugin/commit/8dd292f483cb81e008d769b4588f4cfb118b1d11), the plugin uses pandoc's `html5` output instead of `html`. This may break your existing CSS styling. See [Issue 3](https://github.com/dsanson/jekyll-pandoc-plugin/issues/3) for discussion.
+After this [recent commit][html5] the plugin uses pandoc's `html5` output by
+default instead of `html`. This may break your existing CSS styling. See the
+[Configuration](#configuration) section if you'd like to go back to using
+`html` output.
+
+[html5]: https://github.com/dsanson/jekyll-pandoc-plugin/commit/8dd292f483cb81e008d769b4588f4cfb118b1d11
 
 Installation
 ------------
@@ -30,25 +35,33 @@ create it.)
 Configuration
 -------------
 
-To tell jekyll to use pandoc to convert markdown, add
+To tell jekyll to use pandoc to convert markdown, add the following line to
+your `_config.yml`.
 
     markdown: pandoc
 
-to your `_config.yml` file. If you want to pass options to pandoc, you
-can add something like
+This plugin supports two configuration options for pandoc. Specify them both in
+the pandoc section of your `_config.yml`.
+
+- `format` - the output format to use, e.g., `html5` (default) and `html`.
+- `extensions` - A list or hash of pandoc extensions to enable.
+
+If none of the extensions you're using take arguments, then `extensions` can be
+a list:
 
     pandoc:
-       extensions: [smart, mathjax]
+      format: html5
+      extensions: [smart, mathjax]
 
-to your `_config.yml` file. For more complex options that involve arguments, you will want something like
+If an extention takes options, make extensions a hash that maps each extension
+name to its argument.
 
     pandoc:
-        extensions:
-            - smart
-            - csl: 'apa.csl'
-            - bibliography: 'references.bib'
-
-
+      format: html
+      extensions:
+        - smart
+        - csl: 'apa.csl'
+        - bibliography: 'references.bib'
 
 Github Pages
 ------------

--- a/pandoc_markdown.rb
+++ b/pandoc_markdown.rb
@@ -59,7 +59,9 @@ module Jekyll
 
         def convert(content)
           extensions = config_option('extensions', [])
-          PandocRuby.new(content, *extensions).to_html5
+          format = config_option('format', 'html5')
+
+          PandocRuby.new(content, *extensions).send("to_#{format}")
         end
 
         def config_option(key, default=nil)

--- a/pandoc_markdown.rb
+++ b/pandoc_markdown.rb
@@ -4,7 +4,7 @@ class Jekyll::MarkdownConverter
 
   def convert(content)
     return super unless ( @config['markdown'] == 'pandoc' || @config['pandoc'] )
-    @pandoc_extensions = @config['pandoc']['extensions'].map { |e| e.to_sym }
+    @pandoc_extensions = @config['pandoc']['extensions']
     PandocRuby.new(content, *@pandoc_extensions).to_html
   end
 end

--- a/pandoc_markdown.rb
+++ b/pandoc_markdown.rb
@@ -49,7 +49,7 @@ module Jekyll
     class Markdown
       class PandocParser
         def initialize(config)
-	  require 'pandoc-ruby'
+          require 'pandoc-ruby'
           @config = config
         rescue LoadError
           STDERR.puts 'You are missing a library required for Pandoc. Please run:'
@@ -58,11 +58,15 @@ module Jekyll
         end
 
         def convert(content)
-          @pandoc_extensions = case @config['pandoc']
-            when nil then []
-            else @config['pandoc'].fetch('extensions', [])
+          extensions = config_option('extensions', [])
+          PandocRuby.new(content, *extensions).to_html5
+        end
+
+        def config_option(key, default=nil)
+          case @config['pandoc']
+            when nil then default
+            else @config['pandoc'].fetch(key, default)
           end
-          PandocRuby.new(content, *@pandoc_extensions).to_html5
         end
       end
     end

--- a/pandoc_markdown.rb
+++ b/pandoc_markdown.rb
@@ -58,8 +58,11 @@ module Jekyll
         end
 
         def convert(content)
-	  @pandoc_extensions = @config['pandoc']['extensions']
-	  PandocRuby.new(content, *@pandoc_extensions).to_html5
+          @pandoc_extensions = case @config['pandoc']
+            when nil then []
+            else @config['pandoc'].fetch('extensions', [])
+          end
+          PandocRuby.new(content, *@pandoc_extensions).to_html5
         end
       end
     end

--- a/pandoc_markdown.rb
+++ b/pandoc_markdown.rb
@@ -1,10 +1,67 @@
-require 'pandoc-ruby'
+module Jekyll
+  module Converters
+    class Markdown < Converter
+      safe true
 
-class Jekyll::MarkdownConverter
+      pygments_prefix "\n"
+      pygments_suffix "\n"
 
-  def convert(content)
-    return super unless ( @config['markdown'] == 'pandoc' || @config['pandoc'] )
-    @pandoc_extensions = @config['pandoc']['extensions']
-    PandocRuby.new(content, *@pandoc_extensions).to_html5
+      def setup
+        return if @setup
+        @parser = case @config['markdown']
+          when 'redcarpet'
+            RedcarpetParser.new @config
+          when 'kramdown'
+            KramdownParser.new @config
+          when 'rdiscount'
+            RDiscountParser.new @config
+          when 'maruku'
+            MarukuParser.new @config
+          when 'pandoc'
+            PandocParser.new @config
+          else
+            STDERR.puts "Invalid Markdown processor: #{@config['markdown']}"
+            STDERR.puts " Valid options are [ maruku | rdiscount | kramdown ]"
+            raise FatalException.new("Invalid Markdown process: #{@config['markdown']}")
+        end
+        @setup = true
+      end
+
+      def matches(ext)
+        rgx = '(' + @config['markdown_ext'].gsub(',','|') +')'
+        ext =~ Regexp.new(rgx, Regexp::IGNORECASE)
+      end
+
+      def output_ext(ext)
+        ".html"
+      end
+
+      def convert(content)
+        setup
+        @parser.convert(content)
+      end
+    end
+  end
+end
+
+module Jekyll
+  module Converters
+    class Markdown
+      class PandocParser
+        def initialize(config)
+	  require 'pandoc-ruby'
+          @config = config
+        rescue LoadError
+          STDERR.puts 'You are missing a library required for Pandoc. Please run:'
+          STDERR.puts ' $ [sudo] gem install pandoc-ruby'
+          raise FatalException.new("Missing dependency: pandoc-ruby")
+        end
+
+        def convert(content)
+	  @pandoc_extensions = @config['pandoc']['extensions']
+	  PandocRuby.new(content, *@pandoc_extensions).to_html5
+        end
+      end
+    end
   end
 end

--- a/pandoc_markdown.rb
+++ b/pandoc_markdown.rb
@@ -1,74 +1,16 @@
 module Jekyll
   module Converters
-    class Markdown < Converter
-      safe true
-
-      pygments_prefix "\n"
-      pygments_suffix "\n"
-
-      def setup
-        return if @setup
-        @parser = case @config['markdown']
-          when 'redcarpet'
-            RedcarpetParser.new @config
-          when 'kramdown'
-            KramdownParser.new @config
-          when 'rdiscount'
-            RDiscountParser.new @config
-          when 'maruku'
-            MarukuParser.new @config
-          when 'pandoc'
-            PandocParser.new @config
-          else
-            STDERR.puts "Invalid Markdown processor: #{@config['markdown']}"
-            STDERR.puts " Valid options are [ maruku | rdiscount | kramdown ]"
-            raise FatalException.new("Invalid Markdown process: #{@config['markdown']}")
-        end
-        @setup = true
-      end
-
-      def matches(ext)
-        rgx = '(' + @config['markdown_ext'].gsub(',','|') +')'
-        ext =~ Regexp.new(rgx, Regexp::IGNORECASE)
-      end
-
-      def output_ext(ext)
-        ".html"
-      end
-
-      def convert(content)
-        setup
-        @parser.convert(content)
-      end
-    end
-  end
-end
-
-module Jekyll
-  module Converters
     class Markdown
-      class PandocParser
+      class Pandoc
         def initialize(config)
-          require 'pandoc-ruby'
-          @config = config
-        rescue LoadError
-          STDERR.puts 'You are missing a library required for Pandoc. Please run:'
-          STDERR.puts ' $ [sudo] gem install pandoc-ruby'
-          raise FatalException.new("Missing dependency: pandoc-ruby")
+          Jekyll::External.require_with_graceful_fail "pandoc-ruby"
+          @config = config["pandoc"] || {}
         end
 
         def convert(content)
-          extensions = config_option('extensions', [])
-          format = config_option('format', 'html5')
-
-          PandocRuby.new(content, *extensions).send("to_#{format}")
-        end
-
-        def config_option(key, default=nil)
-          case @config['pandoc']
-            when nil then default
-            else @config['pandoc'].fetch(key, default)
-          end
+          extensions = @config['extensions'] || []
+          format = @config['format'] || 'html5'
+          ::PandocRuby.new(content, *extensions).send("to_#{format}")
         end
       end
     end

--- a/pandoc_markdown.rb
+++ b/pandoc_markdown.rb
@@ -5,6 +5,6 @@ class Jekyll::MarkdownConverter
   def convert(content)
     return super unless ( @config['markdown'] == 'pandoc' || @config['pandoc'] )
     @pandoc_extensions = @config['pandoc']['extensions']
-    PandocRuby.new(content, *@pandoc_extensions).to_html
+    PandocRuby.new(content, *@pandoc_extensions).to_html5
   end
 end


### PR DESCRIPTION
The original owner deleted his repository and this one becomes the parent.

Among the folks, only multidis/jekyll-pandoc-plugin and elliottslaughter/jekyll-pandoc-plugin are different with (and ahead of) the original owner's 20 commits.

And among the 2, elliottslaughter/jekyll-pandoc-plugin are newest and support Jekyll 3. Hence it is natural to pull request from that to the parent.

If you do not wish to own the project, please delete this repository.
